### PR TITLE
Sets goban height and width to match svg.

### DIFF
--- a/src/main.ts
+++ b/src/main.ts
@@ -34,11 +34,15 @@ export default class ObsidianGoban extends Plugin {
         "viewBox",
         "0 0 " + boxWidth + " " + boxHeight
       );
-      block.setAttributeNS(null, "width", String(boxWidth));
-      block.setAttributeNS(null, "height", String(boxHeight));
+      block.setAttributeNS(null, "width", String(this.roundNumberToTens(boxWidth)));
+      block.setAttributeNS(null, "height", String(this.roundNumberToTens(boxHeight)));
       block.innerHTML = svgGoban.xml;
       block.style.display = "block";
       el.appendChild(block);
     };
+  }
+
+  private roundNumberToTens(num : number) : number {
+    return Math.ceil(num / 10) * 10;
   }
 }

--- a/src/main.ts
+++ b/src/main.ts
@@ -26,8 +26,8 @@ export default class ObsidianGoban extends Plugin {
       //const svgGobanDOM = parser.parseFromString(svgGoban, "image/svg+xml");
 
       const xmlns = "http://www.w3.org/2000/svg";
-      var boxWidth = 320;
-      var boxHeight = 320;
+      var boxWidth = svgGoban.width ?? 320;
+      var boxHeight = svgGoban.height ?? 320;
       var block = document.createElementNS(xmlns, "svg");
       block.setAttributeNS(
         null,
@@ -36,7 +36,7 @@ export default class ObsidianGoban extends Plugin {
       );
       block.setAttributeNS(null, "width", String(boxWidth));
       block.setAttributeNS(null, "height", String(boxHeight));
-      block.innerHTML = svgGoban;
+      block.innerHTML = svgGoban.xml;
       block.style.display = "block";
       el.appendChild(block);
     };

--- a/src/sltxt2svg.ts
+++ b/src/sltxt2svg.ts
@@ -364,16 +364,18 @@ export class GoDiagram {
     return svgError;
   }
 
-  createSVG() /** Create the SVG image based on ASCII diagram
-   *   returns an SVG object (an XML text file)
-   **/ {
+  createSVG() 
+   /** Create the SVG image based on ASCII diagram
+    *  returns an SVG object (an XML text file), and the svg's width and height.
+    **/
+  : {xml: string, width: number | null, height: number | null} {
     // parse input diagram, create error SVG if failed
     let errorClass = "";
 
     if (this.diagram === null) {
       //parsing failed
       this.failureErrorMessage = "Parsing of ASCII diagram failed";
-      return this.createSvgErrorMessage(errorClass);
+      return { xml: this.createSvgErrorMessage(errorClass), width: null, height: null};
     } else {
       // parsing succeeded --> create SVG diagram
       var imgSvg: Record<string, string> = {};
@@ -644,7 +646,7 @@ export class GoDiagram {
         imgSvg["coordinates"] +
         imgSvg["closeSvgTag"];
 
-      return svgElement;
+      return {xml: svgElement, width: this.imageWidth, height: this.imageHeight};
     }
   }
 


### PR DESCRIPTION
Original script defaulted to always creating a 320 x 320 block diagram when rendered. After this commit, we use the height and width attributes of the svg to set the correct size on the rendered block diagram.  Because the goban has not rendered in Obsidian yet, we update the sltxt2svg script to return the correct image sizes when it returns the xml, and then we use those values.